### PR TITLE
Facebook pages selection and dynamic app permissions

### DIFF
--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Dialogs/FacebookOAuth.aspx.cs
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Dialogs/FacebookOAuth.aspx.cs
@@ -84,7 +84,6 @@ namespace Skybrud.Social.Umbraco.App_Plugins.Skybrud.Social.Dialogs {
                 AppId = options.AppId,
                 AppSecret = options.AppSecret,
                 RedirectUri = options.RedirectUri
-                //TODO: Adicionar array p/ escolha de múltiplas permissões
             };
 
             // Session expired?
@@ -109,7 +108,7 @@ namespace Skybrud.Social.Umbraco.App_Plugins.Skybrud.Social.Dialogs {
                 Session["Skybrud.Social_" + state] = new[] {Callback, ContentTypeAlias, PropertyAlias};
 
                 // Construct the authorization URL
-                string url = client.GetAuthorizationUrl(state, "manage_pages", /*"user_posts",*/ "user_status", "user_about_me", "user_photos");//TODO: Set permissions dinamically
+                string url = client.GetAuthorizationUrl(state, options.Permissions);
                 
                 // Redirect the user
                 Response.Redirect(url);

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/Controllers.js
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/Controllers.js
@@ -99,8 +99,23 @@ angular.module("umbraco").controller("Skybrud.Social.Facebook.OAuth.PreValues.Co
     if (!$scope.model.value.permissions) {
         $scope.model.value.permissions = [];
     }
+    
+    //https://developers.facebook.com/docs/facebook-login/permissions/v2.4#reference
+    $scope.allPermissions = [
+        //Permissions That Do Not Require Review
+        "public_profile", "user_friends", "email",
 
-    $scope.allPermissions = ["user_about_me", "user_photos", "user_status", "user_likes", "user_posts", "manage_pages"];
+        //Extended Profile Properties
+        "user_about_me", "user_birthday",
+        "user_hometown", "user_likes", "user_location", "user_managed_groups",
+        "user_photos", "user_posts", "user_status", "user_videos",
+        /*
+        "user_education_history", "user_events", "user_games_activity", "user_website", "user_work_history",
+        "user_actions.books", "user_actions.fitness", "user_actions.music", "user_actions.news", "user_actions.video",
+        */
+        //Extended Permissions
+        "manage_pages", "publish_pages", "publish_actions"
+    ];
 
     $scope.suggestedRedirectUri = window.location.origin + '/App_Plugins/Skybrud.Social/Dialogs/FacebookOAuth.aspx';
 
@@ -116,4 +131,5 @@ angular.module("umbraco").controller("Skybrud.Social.Facebook.OAuth.PreValues.Co
             $scope.model.value.permissions.push(permName);
         }
     };
+    //TODO: remove all elements after UI loads and then rebuild array only with current checked permissions
 }]);

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/Controllers.js
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/Controllers.js
@@ -10,39 +10,32 @@
     
     $scope.callback = function (data) {
 
-        $scope.model.value = data;//Diogo: Seta o JSON retornado pelo FacebookOAuth.aspx como valor do MODEL
+        $scope.model.value = data;
 
-        //Diogo: Carrega dados quando autoriza pela 1° vez
         updateUI();
 
-        //Diogo: carregar dropDownList() com business Pages
         updateBusinessPagesDropdownUI();
     };
 
 
     function updateBusinessPagesDropdownUI() {
 
-        //load itens do COMBO
         var array = $scope.model.value.business_pages;
         if (array) {
-            //for (var i = 0; i < array.length; i++) {
-            //    console.log(array[i]);
-            //}
-            //se possui accounts carrega no dropdown
+            //for (var i = 0; i < array.length; i++)
+            //  console.log(array[i]);
             $scope.accounts = array;
         }
 
-
-        //TODO: se tiver o ID de uma página salva, carrega os dados no MODEL e seta no combo
+        //Whether there is a selected account, bind data
         if ($scope.model.value && $scope.model.value.selected_business_page) {
             $scope.selectedBusinessPage = $scope.model.value.selected_business_page;
         }
 
-
-        //registra EVENTO ao selecionar valor no combo
+        //Register onChange event
         $scope.businessPageSelected = function (selectedAccount) {
-            $scope.selectedBusinessPage = selectedAccount;//facilidade de acesso na View!
-            $scope.model.value.selected_business_page = selectedAccount;//persistência no Umbraco!
+            $scope.selectedBusinessPage = selectedAccount;
+            $scope.model.value.selected_business_page = selectedAccount;//persists on Umbraco model
         };
     }
 
@@ -82,9 +75,9 @@
 
     }
 
-    //entrou na página tenta carregar DADOS salvos
+    //load stored data in content editor (UI)
     updateUI();
-    updateBusinessPagesDropdownUI();//Diogo:
+    updateBusinessPagesDropdownUI();
 
     // Register the callback function in the global scope
     window[alias] = $scope.callback;

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/Controllers.js
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/Controllers.js
@@ -90,12 +90,30 @@ angular.module("umbraco").controller("Skybrud.Social.Facebook.OAuth.PreValues.Co
         $scope.model.value = {
             appid: '',
             appsecret: '',
-            redirecturi: ''
+            redirecturi: '',
+            permissions: []
         };
     }
+
+    //case permissions does not exist (update)
+    if (!$scope.model.value.permissions) {
+        $scope.model.value.permissions = [];
+    }
+
+    $scope.allPermissions = ["user_about_me", "user_photos", "user_status", "user_likes", "user_posts", "manage_pages"];
 
     $scope.suggestedRedirectUri = window.location.origin + '/App_Plugins/Skybrud.Social/Dialogs/FacebookOAuth.aspx';
 
     assetsService.loadCss("/App_Plugins/Skybrud.Social/Social.css");
 
+    $scope.toggleSelection = function toggleSelection(permName) {
+        var idx = $scope.model.value.permissions.indexOf(permName);
+        
+        if (idx > -1) {// is currently selected
+            $scope.model.value.permissions.splice(idx, 1);
+        }
+        else {// is newly selected
+            $scope.model.value.permissions.push(permName);
+        }
+    };
 }]);

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/Controllers.js
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/Controllers.js
@@ -7,14 +7,44 @@
     var state = editorState.current;
 
     $scope.expiresDays = null;
-
+    
     $scope.callback = function (data) {
 
-        $scope.model.value = data;
+        $scope.model.value = data;//Diogo: Seta o JSON retornado pelo FacebookOAuth.aspx como valor do MODEL
 
+        //Diogo: Carrega dados quando autoriza pela 1° vez
         updateUI();
 
+        //Diogo: carregar dropDownList() com business Pages
+        updateBusinessPagesDropdownUI();
     };
+
+
+    function updateBusinessPagesDropdownUI() {
+
+        //load itens do COMBO
+        var array = $scope.model.value.business_pages;
+        if (array) {
+            //for (var i = 0; i < array.length; i++) {
+            //    console.log(array[i]);
+            //}
+            //se possui accounts carrega no dropdown
+            $scope.accounts = array;
+        }
+
+
+        //TODO: se tiver o ID de uma página salva, carrega os dados no MODEL e seta no combo
+        if ($scope.model.value && $scope.model.value.selected_business_page) {
+            $scope.selectedBusinessPage = $scope.model.value.selected_business_page;
+        }
+
+
+        //registra EVENTO ao selecionar valor no combo
+        $scope.businessPageSelected = function (selectedAccount) {
+            $scope.selectedBusinessPage = selectedAccount;//facilidade de acesso na View!
+            $scope.model.value.selected_business_page = selectedAccount;//persistência no Umbraco!
+        };
+    }
 
     $scope.authorize = function () {
 
@@ -52,7 +82,9 @@
 
     }
 
+    //entrou na página tenta carregar DADOS salvos
     updateUI();
+    updateBusinessPagesDropdownUI();//Diogo:
 
     // Register the callback function in the global scope
     window[alias] = $scope.callback;

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/PreValueEditor.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/PreValueEditor.html
@@ -39,13 +39,13 @@
     <div class="option">
         <label>
             <div>
-                <span>Manage Facebook Permissions</span>
-                <small>Facebook permissions that will be asked in your app</small>
+                <span>App Permissions</span>
+                <small>Permissions asked by your Facebook app</small>
             </div>
         </label>
         <div style="clear: both;"></div>
-        <div style="display:block; float: left; margin-right: 10px;">
-            <label style="display:inline" ng-repeat="permName in allPermissions">
+        <div style="display:block; margin-right: 10px;">
+            <label style="display: inline; padding-right: 10px !important" ng-repeat="permName in allPermissions">
                 <input type="checkbox" name="model.value.permissions[]" value="{{permName}}"
                     ng-checked="model.value.permissions.indexOf(permName) > -1" ng-click="toggleSelection(permName)"> {{permName}}
             </label>

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/PreValueEditor.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/PreValueEditor.html
@@ -35,6 +35,22 @@
             <input type="text" ng-model="model.value.appsecret" />
         </label>
     </div>
+
+    <div class="option">
+        <label>
+            <div>
+                <span>Manage Facebook Permissions</span>
+                <small>Facebook permissions that will be asked in your app</small>
+            </div>
+        </label>
+        <div style="clear: both;"></div>
+        <div style="display:block; float: left; margin-right: 10px;">
+            <label style="display:inline" ng-repeat="permName in allPermissions">
+                <input type="checkbox" name="model.value.permissions[]" value="{{permName}}"
+                    ng-checked="model.value.permissions.indexOf(permName) > -1" ng-click="toggleSelection(permName)"> {{permName}}
+            </label>
+        </div>
+    </div>
     
     <div class="option">
         <label>

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/PropertyEditor.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/PropertyEditor.html
@@ -26,7 +26,7 @@
         </div>
         <div style="clear: both;"></div>
         
-        <div style="float: left; margin-right: 10px;">
+        <div style="float: left; margin-right: 10px;" ng-show="accounts">
             <h5>Business Page Accounts</h5>
             <select name="business-page" ng-model="selectedBusinessPage" ng-change="businessPageSelected(selectedBusinessPage)" ng-options="bp.name for bp in accounts track by bp.id">
                 <option value="">choose an account...</option>

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/PropertyEditor.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/PropertyEditor.html
@@ -25,8 +25,23 @@
             </div>
         </div>
         <div style="clear: both;"></div>
+        
+        <div style="float: left; margin-right: 10px;">
+            <h5>Business Page Accounts</h5>
+            <select name="business-page" ng-model="selectedBusinessPage" ng-change="businessPageSelected(selectedBusinessPage)" ng-options="bp.name for bp in accounts track by bp.id">
+                <option value="">choose an account...</option>
+            </select>
+        </div>
+		<div style="clear: both;"></div>
+        <div style="float: left; margin-right: 10px;" ng-show="selectedBusinessPage">
+            <hr />
+            <h5>Business Page Selected</h5>
+            <span><strong>Id:</strong> {{ selectedBusinessPage.id }}</span><br />
+            <span><strong>Name:</strong> {{ selectedBusinessPage.name }}</span>
+            <!--<br /><span><strong>Access Token:</strong> {{ selectedBusinessPage.access_token }}</span>-->
+        </div>
     </div>
-    
+
     <div ng-show="!model.value">
         <button ng-click="authorize()" prevent-default="" class="btn">Authorize</button>
     </div>

--- a/src/Skybrud.Social.Umbraco/Facebook/PropertyEditors/OAuth/FacebookOAuthData.cs
+++ b/src/Skybrud.Social.Umbraco/Facebook/PropertyEditors/OAuth/FacebookOAuthData.cs
@@ -4,20 +4,6 @@ using Skybrud.Social.Facebook;
 
 namespace Skybrud.Social.Umbraco.Facebook.PropertyEditors.OAuth {
 
-    //Diogo:::
-    public class FacebookBusinessPageData
-    {
-        [JsonProperty("id")]
-        public string Id { get; set; }
-        
-        [JsonProperty("name")]
-        public string Name { get; set; }
-        
-        [JsonProperty("access_token")]
-        public string AccessToken { get; set; }
-    }
-
-
     public class FacebookOAuthData {
 
         #region Private fields
@@ -59,14 +45,18 @@ namespace Skybrud.Social.Umbraco.Facebook.PropertyEditors.OAuth {
         [JsonProperty("scope")]
         public string[] Scope { get; set; }
 
+        /// <summary>
+        /// Gets an array of business accounts (pages).
+        /// Requires "manage_pages" permission
+        /// </summary>
+        [JsonProperty("business_pages")]
+        public FacebookBusinessPageData[] BusinessPages { get; set; }
 
-[JsonProperty("business_pages")]
-public FacebookBusinessPageData[] BusinessPages { get; set; }
-
-[JsonProperty("selected_business_page")]
-public FacebookBusinessPageData SelectedBusinessPage { get; set; }//Inicial = NULL
-
-
+        /// <summary>
+        /// Stores a Business Page data selected by the user
+        /// </summary>
+        [JsonProperty("selected_business_page")]
+        public FacebookBusinessPageData SelectedBusinessPage { get; set; }
 
         /// <summary>
         /// Gets whether the OAuth data is valid - that is whether the OAuth data has a valid
@@ -107,6 +97,17 @@ public FacebookBusinessPageData SelectedBusinessPage { get; set; }//Inicial = NU
 
         #endregion
 
+    }
+
+    public class FacebookBusinessPageData {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
     }
 
 }

--- a/src/Skybrud.Social.Umbraco/Facebook/PropertyEditors/OAuth/FacebookOAuthData.cs
+++ b/src/Skybrud.Social.Umbraco/Facebook/PropertyEditors/OAuth/FacebookOAuthData.cs
@@ -3,7 +3,21 @@ using Newtonsoft.Json;
 using Skybrud.Social.Facebook;
 
 namespace Skybrud.Social.Umbraco.Facebook.PropertyEditors.OAuth {
-    
+
+    //Diogo:::
+    public class FacebookBusinessPageData
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+        
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+    }
+
+
     public class FacebookOAuthData {
 
         #region Private fields
@@ -44,6 +58,15 @@ namespace Skybrud.Social.Umbraco.Facebook.PropertyEditors.OAuth {
         /// </summary>
         [JsonProperty("scope")]
         public string[] Scope { get; set; }
+
+
+[JsonProperty("business_pages")]
+public FacebookBusinessPageData[] BusinessPages { get; set; }
+
+[JsonProperty("selected_business_page")]
+public FacebookBusinessPageData SelectedBusinessPage { get; set; }//Inicial = NULL
+
+
 
         /// <summary>
         /// Gets whether the OAuth data is valid - that is whether the OAuth data has a valid

--- a/src/Skybrud.Social.Umbraco/Facebook/PropertyEditors/OAuth/FacebookOAuthPreValueOptions.cs
+++ b/src/Skybrud.Social.Umbraco/Facebook/PropertyEditors/OAuth/FacebookOAuthPreValueOptions.cs
@@ -15,12 +15,16 @@ namespace Skybrud.Social.Umbraco.Facebook.PropertyEditors.OAuth {
         [JsonProperty("redirecturi")]
         public string RedirectUri { get; set; }
 
+        [JsonProperty("permissions")]
+        public string[] Permissions { get; set; }
+
         [JsonIgnore]
         public bool IsValid {
             get {
                 if (String.IsNullOrEmpty(AppId)) return false;
                 if (String.IsNullOrEmpty(AppSecret)) return false;
                 if (String.IsNullOrEmpty(RedirectUri)) return false;
+                if (Permissions == null || Permissions.Length == 0) return false;
                 return true;
             }
         }


### PR DESCRIPTION
Hello again abjerner!

I've extend your Facebook OAuth datatype to achieve the following functionalities:
- get business pages (accounts) data from user and allow him to select and store one
  - It is **optional** and it does not brake previous version
  - Data is stored in umbraco.config
  - Details are below:
  - Initial view: when user allows "manage_pages" scope and has accounts ![initial-view](https://cloud.githubusercontent.com/assets/11685527/10118615/34cbcd3e-6453-11e5-9836-457a16801776.png)
  - User selected an account ![selected-view](https://cloud.githubusercontent.com/assets/11685527/10118617/429ed82a-6453-11e5-814a-5b464b39a02c.png)
  - when user does not allow "manage_pages" the dropdown list is hidden
    ![no-permission-granted](https://cloud.githubusercontent.com/assets/11685527/10118619/500d45a0-6453-11e5-9875-3586ae0a3c83.png)
- choose permissions/scopes asked by Facebook App in datatype editor dynamically (in images below you can see it working):
  ![datatype-choose-scopes](https://cloud.githubusercontent.com/assets/11685527/10118654/5f147504-6454-11e5-8985-a12fa82fd85f.png)
  **Notes**: the presentation/CSS for dynamic permissions is not beautiful but it works!
  - Facebook app asking those permissions
    ![facebook-asking-email-likes-hometown](https://cloud.githubusercontent.com/assets/11685527/10101559/cefd6384-636f-11e5-8359-fa21cc86c6c3.png)
  - Detail ![permission-detail](https://cloud.githubusercontent.com/assets/11685527/10118630/82f65bdc-6453-11e5-9c71-c4ec597746b7.png)
  - Manage Pages scope
    ![facebook-asking-manage_pages](https://cloud.githubusercontent.com/assets/11685527/10101596/fb4d561a-636f-11e5-82a7-4220a44548d7.png)
