### PR TITLE
Google OAuth - support for selecting scopes

### DIFF
--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Dialogs/GoogleOAuth.aspx.cs
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Dialogs/GoogleOAuth.aspx.cs
@@ -122,11 +122,13 @@ namespace Skybrud.Social.Umbraco.App_Plugins.Skybrud.Social.Dialogs {
                 };
 
                 // Declare the scope
-                GoogleScopeCollection scope = new[] {
+                GoogleScopeCollection defaultScope = new[] {
                     GoogleScope.OpenId,
                     GoogleScope.Email,
                     GoogleScope.Profile
                 };
+
+                string scope = options.Scope != null ? string.Join(" ", options.Scope) : defaultScope.ToString();
 
                 // Construct the authorization URL
                 string url = client.GetAuthorizationUrl(state, scope, GoogleAccessType.Offline, GoogleApprovalPrompt.Force);

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/Controllers.js
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/Controllers.js
@@ -31,15 +31,39 @@
 
 }]);
 
-angular.module("umbraco").controller("Skybrud.Social.Google.OAuth.PreValues.Controller", ['$scope', '$http', 'assetsService', function ($scope, $http, assetsService) {
+angular.module("umbraco").controller("Skybrud.Social.Google.OAuth.PreValues.Controller", ['$scope', '$http', 'dialogService', function ($scope, $http, dialogService) {
 
     if (!$scope.model.value) {
         $scope.model.value = {
             appid: '',
             appsecret: '',
-            redirecturi: ''
+            redirecturi: '',
+            scope: ['email', 'openid', 'profile']
         };
     }
+
+    if (!$scope.model.value.scope) $scope.model.value.scope = [];
+
+    $scope.addScope = function () {
+
+        var d = dialogService.open({
+            modalClass: 'SocialDialog',
+            template: '/App_Plugins/Skybrud.Social/Google/OAuth/ScopesDialog.html',
+            show: true,
+            callback: function (scopes) {
+                $scope.model.value.scope = scopes;
+            },
+            selection: $scope.model.value.scope
+        });
+
+        d.element[0].style.width = '1000px';
+        d.element[0].style.marginLeft = '-500px';
+
+    };
+
+    $scope.removeScope = function (index) {
+        $scope.model.value.scope.splice(index, 1);
+    };
 
     $scope.suggestedRedirectUri = window.location.origin + '/App_Plugins/Skybrud.Social/Dialogs/GoogleOAuth.aspx';
 

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/Dialogs.js
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/Dialogs.js
@@ -1,0 +1,43 @@
+﻿angular.module("umbraco").controller("socialGoogleScopesDialogCtrl", function ($scope, $http) {
+
+    var selection = Array.isArray($scope.dialogOptions.selection) ? $scope.dialogOptions.selection : [];
+
+    $scope.count = 0;
+
+    $scope.update = function() {
+        var count = 0;
+        angular.forEach($scope.scopes, function(group) {
+            angular.forEach(group.scopes, function(scope) {
+                if (scope.checked) count++;
+            });
+        });
+        $scope.count = count;
+    };
+
+    $scope.confirm = function() {
+        var temp = [];
+        angular.forEach($scope.scopes, function(group) {
+            angular.forEach(group.scopes, function(scope) {
+                if (scope.checked) {
+                    temp.push(scope.Name);
+                }
+            });
+        });
+        $scope.submit(temp);
+    };
+
+    $http.get('/umbraco/SkybrudSocial/Google/GetScopes').success(function (r) {
+        $scope.scopes = r;
+        var count = 0;
+        angular.forEach($scope.scopes, function (group) {
+            angular.forEach(group.scopes, function (scope) {
+                scope.checked = selection.indexOf(scope.Name) >= 0;
+                if (scope.checked) {
+                    count++;
+                }
+            });
+        });
+        $scope.count = count;
+    });
+
+});

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/PreValueEditor.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/PreValueEditor.html
@@ -1,4 +1,4 @@
-﻿<div class="skybrudsocialprevalue" ng-controller="Skybrud.Social.Google.OAuth.PreValues.Controller">
+﻿<div class="skybrudsocialprevalue2" ng-controller="Skybrud.Social.Google.OAuth.PreValues.Controller">
 
     <small>
         Google uses <strong>OAuth 2.0</strong> for authentication and communication. In order for
@@ -6,48 +6,64 @@
         of your Google app. You can create a new app at the following URL:
         <strong>https://console.developers.google.com/project</strong><br />
         <br />
-        <strong>Notice:</strong> When a user authenticates with the Google API, a refresh token is
-        saved along with information about the user. The refresh token can be used to obtain an
-        access token, which again can be used to make calls to the Google API. Refresh tokens will
-        not expire unless the user deauthorizes the app. Access tokens will only have a lifetime of
-        about an hour.<br />
-        <br />
-        <strong>Notice:</strong> When a user is redirected to the Google login dialog, the scope
-        (permissions of the app) is specified. It is currently not possible to specify a scope, but
-        this will be possible in a future version of this package. The current scope sent to the
-        login dialog is: <samp>openid email profile</samp>.
+        <div class="notice icon">
+            <i class="icon icon-info"></i>
+            <div>
+                When a user authenticates with the Google API, a refresh token is
+                saved along with information about the user. The refresh token can be used to obtain an
+                access token, which again can be used to make calls to the Google API. Refresh tokens will
+                not expire unless the user deauthorizes the app. Access tokens will only have a lifetime of
+                about an hour.<br />
+            </div>
+        </div>
     </small>
 
     <div class="option">
-        <label>
-            <div>
-                <span>Client ID</span>
-                <small>The ID of the Google app.</small>
-            </div>
-            <input type="text" ng-model="model.value.clientid" />
+        <label for="clientid">
+            <span>Client ID</span>
+            <small>The ID of the Google app.</small>
         </label>
+        <div>
+            <input id="clientid" type="text" ng-model="model.value.clientid" />
+        </div>
     </div>
     
     <div class="option">
-        <label>
-            <div>
-                <span>Client Secret</span>
-                <small>The secret of the Google app.</small>
-            </div>
-            <input type="text" ng-model="model.value.clientsecret" />
+        <label for="clientsecret">
+            <span>Client Secret</span>
+            <small>The secret of the Google app.</small>
         </label>
+        <div>
+            <input id="clientsecret" type="text" ng-model="model.value.clientsecret" />
+        </div>
     </div>
     
     <div class="option">
-        <label>
-            <div>
-                <span>Redirect URI</span>
-                <small>The redirect URI of the Google app.</small>
-            </div>
-            <input type="text" ng-model="model.value.redirecturi" />
+        <label for="redirecturi">
+            <span>Redirect URI</span>
+            <small>The redirect URI of the Google app.</small>
         </label>
-        <div ng-show="model.value.redirecturi == ''" class="suggestion">
-            Will most likely be: {{suggestedRedirectUri}}
+        <div>
+            <input id="redirecturi" type="text" ng-model="model.value.redirecturi" />
+            <div ng-show="model.value.redirecturi == ''" class="suggestion">
+                Will most likely be: {{suggestedRedirectUri}}
+            </div>
+        </div>
+    </div>
+
+    <div class="option">
+        <label>
+            <span>Scope</span>
+            <small>The scope of the app (the permissions your app should be granted).</small>
+        </label>
+        <div class="scopes">
+            <span ng-repeat="scope in model.value.scope" class="label scope">
+                {{scope}}
+                <i class="icon icon-delete" ng-click="removeScope($index)"></i>
+            </span>
+            <span ng-click="addScope();" class="label scope add">
+                <i class="icon icon-add"></i>
+            </span>
         </div>
     </div>
 

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/ScopesDialog.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/ScopesDialog.html
@@ -1,0 +1,35 @@
+﻿<div ng-controller="socialGoogleScopesDialogCtrl">
+    <div class="SocialDialogHeader">
+        <div class="SocialDialogClose" ng-click="close();"></div>
+        <div class="SocialDialogTitle">Select scopes</div>
+    </div>
+    <div class="SocialDialogContent">
+        <div ng-repeat="group in scopes">
+            <div class="table scopes">
+                <table>
+                    <thead>
+                        <tr>
+                            <th colspan="3">{{group.name}}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr ng-repeat="scope in group.scopes">
+                            <td class="col-checkbox">
+                                <input type="checkbox" ng-model="scope.checked" ng-change="update();" />
+                            </td>
+                            <td class="col-name">{{scope.Name}}</td>
+                            <td class="col-description">
+                                <span ng-show="scope.Description">{{scope.Description}}</span>
+                                <em ng-show="!scope.Description">No description.</em>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <pre style="font-size: 11px; line-height: 13px;">{{dialogOptions.hest | json}}</pre>
+    </div>
+    <div class="SocialDialogFooter">
+        <a class="btn btn-success" ng-click="confirm();">Confirm ({{count}})</a>
+    </div>
+</div>

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/package.manifest
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/package.manifest
@@ -73,6 +73,7 @@
         "/App_Plugins/Skybrud.Social/Facebook/OAuth/Controllers.js",
         "/App_Plugins/Skybrud.Social/Facebook/OAuth/Dialogs.js",
         "/App_Plugins/Skybrud.Social/Google/OAuth/Controllers.js",
+        "/App_Plugins/Skybrud.Social/Google/OAuth/Dialogs.js",
         "/App_Plugins/Skybrud.Social/Instagram/OAuth/Controllers.js",
         "/App_Plugins/Skybrud.Social/Twitter/OAuth/Controllers.js"
     ],

--- a/src/Skybrud.Social.Umbraco/Controllers/Api/GoogleController.cs
+++ b/src/Skybrud.Social.Umbraco/Controllers/Api/GoogleController.cs
@@ -1,0 +1,68 @@
+﻿using Newtonsoft.Json;
+using Skybrud.Social.Google.Analytics;
+using Skybrud.Social.Google.OAuth;
+using Skybrud.Social.Google.YouTube;
+using Skybrud.Social.Umbraco.Google.Scope;
+using Skybrud.Social.Umbraco.WebApi;
+using Umbraco.Web.Mvc;
+using Umbraco.Web.WebApi;
+
+namespace Skybrud.Social.Umbraco.Controllers.Api
+{
+    [PluginController("SkybrudSocial")]
+    [JsonOnlyConfiguration]
+    public class GoogleController : UmbracoApiController
+    {
+        public object GetScopes()
+        {
+            return new[]
+            {
+                GoogleScopeGroups.Basic,
+                GoogleScopeGroups.Analytics,
+                GoogleScopeGroups.YouTube
+            };
+        }
+    }
+}
+
+namespace Skybrud.Social.Umbraco.Google.Scope
+{
+    internal static class GoogleScopeGroups
+    {
+        public static readonly GoogleScopeGroup Basic = new GoogleScopeGroup("Basic", new[] {
+            GoogleScopes.Email,
+            GoogleScopes.OpenId,
+            GoogleScopes.Profile
+        });
+
+        public static readonly GoogleScopeGroup Analytics = new GoogleScopeGroup("Analytics", new[] {
+            AnalyticsScopes.Readonly,
+            AnalyticsScopes.Write,
+            AnalyticsScopes.Edit,
+            AnalyticsScopes.ManageUsers,
+            AnalyticsScopes.ManageUsersReadonly,
+        });
+
+        public static readonly GoogleScopeGroup YouTube = new GoogleScopeGroup("YouTube", new[] {
+            YouTubeScopes.Readonly,
+            YouTubeScopes.Manage,
+            YouTubeScopes.Upload,
+            YouTubeScopes.PartnerChannelAudit
+        });
+    }
+
+    internal class GoogleScopeGroup
+    {
+        [JsonProperty("name")]
+        public string Name { get; private set; }
+
+        [JsonProperty("scopes")]
+        public GoogleScope[] Scopes { get; private set; }
+
+        public GoogleScopeGroup(string name, GoogleScope[] scopes)
+        {
+            Name = name;
+            Scopes = scopes ?? new GoogleScope[0];
+        }
+    }
+}

--- a/src/Skybrud.Social.Umbraco/Google/PropertyEditors/OAuth/GoogleOAuthPreValueOptions.cs
+++ b/src/Skybrud.Social.Umbraco/Google/PropertyEditors/OAuth/GoogleOAuthPreValueOptions.cs
@@ -6,11 +6,17 @@ namespace Skybrud.Social.Umbraco.Google.PropertyEditors.OAuth {
 
     public class GoogleOAuthPreValueOptions {
 
+        [JsonProperty("clientid")]
         public string ClientId { get; set; }
 
+        [JsonProperty("clientsecret")]
         public string ClientSecret { get; set; }
 
+        [JsonProperty("redirecturi")]
         public string RedirectUri { get; set; }
+
+        [JsonProperty("scope")]
+        public string[] Scope { get; set; }
 
         [JsonIgnore]
         public bool IsValid {

--- a/src/Skybrud.Social.Umbraco/Skybrud.Social.Umbraco.csproj
+++ b/src/Skybrud.Social.Umbraco/Skybrud.Social.Umbraco.csproj
@@ -262,6 +262,7 @@
       <DependentUpon>TwitterOAuth.aspx</DependentUpon>
     </Compile>
     <Content Include="App_Plugins\Skybrud.Social\Facebook\OAuth\Dialogs.js" />
+    <Compile Include="Controllers\Api\GoogleController.cs" />
     <Compile Include="Controllers\Api\FacebookController.cs" />
     <Compile Include="Facebook\PropertyEditors\OAuth\FacebookOAuthPropertyValueConverter.cs" />
     <Compile Include="Facebook\PropertyEditors\OAuth\FacebookOAuthData.cs" />
@@ -290,9 +291,11 @@
     <Content Include="App_Plugins\Skybrud.Social\Facebook\OAuth\PreValueEditor.html" />
     <Content Include="App_Plugins\Skybrud.Social\Facebook\OAuth\PropertyEditor.html" />
     <Content Include="App_Plugins\Skybrud.Social\Facebook\OAuth\ScopesDialog.html" />
+    <Content Include="App_Plugins\Skybrud.Social\Google\OAuth\Dialogs.js" />
     <Content Include="App_Plugins\Skybrud.Social\Google\OAuth\PreValueEditor.html" />
     <Content Include="App_Plugins\Skybrud.Social\Google\OAuth\PropertyEditor.html" />
     <Content Include="App_Plugins\Skybrud.Social\Google\OAuth\Controllers.js" />
+    <Content Include="App_Plugins\Skybrud.Social\Google\OAuth\ScopesDialog.html" />
     <Content Include="App_Plugins\Skybrud.Social\Images\sprite.png" />
     <Content Include="App_Plugins\Skybrud.Social\Instagram\OAuth\Controllers.js" />
     <Content Include="App_Plugins\Skybrud.Social\Instagram\OAuth\PreValueEditor.html" />


### PR DESCRIPTION
Implements #9 for Google OAuth pre-value options.

Displays a dialog with scope options for basic, Analytics and YouTube.

The code follows the same pattern as the Facebook scope options.
It also duplicates some code, (not sure if that's a bad thing at the moment?)