### PR TITLE
Fix scope selection

### DIFF
--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/ScopesDialog.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/ScopesDialog.html
@@ -15,7 +15,7 @@
                     <tbody>
                         <tr ng-repeat="scope in group.scopes">
                             <td class="col-checkbox">
-                                <input type="checkbox" ng-model="scope.checked" ng-change="update();" />
+                                <input type="checkbox" id="fb_scope_{{scope.Name}}" ng-model="scope.checked" ng-change="update();" />
                             </td>
                             <td class="col-name">
                                 <label for="fb_scope_{{scope.Name}}">

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/ScopesDialog.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/ScopesDialog.html
@@ -13,7 +13,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr ng-repeat="scope in group.scopes">
+                        <tr ng-repeat="scope in group.scopes" ng-class="{'selected': scope.checked}">
                             <td class="col-checkbox">
                                 <input type="checkbox" id="fb_scope_{{scope.Name}}" ng-model="scope.checked" ng-change="update();" />
                             </td>

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/ScopesDialog.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/ScopesDialog.html
@@ -13,7 +13,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <tr ng-repeat="scope in group.scopes">
+                        <tr ng-repeat="scope in group.scopes" ng-class="{'selected': scope.checked}">
                             <td class="col-checkbox">
                                 <input type="checkbox" id="g_scope_{{scope.id}}" ng-model="scope.checked" ng-change="update();" />
                             </td>

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/ScopesDialog.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/ScopesDialog.html
@@ -15,10 +15,10 @@
                     <tbody>
                         <tr ng-repeat="scope in group.scopes">
                             <td class="col-checkbox">
-                                <input type="checkbox" id="{{scope.id}}" ng-model="scope.checked" ng-change="update();" />
+                                <input type="checkbox" id="g_scope_{{scope.id}}" ng-model="scope.checked" ng-change="update();" />
                             </td>
                             <td class="col-name">
-                                <label for="{{scope.id}}">
+                                <label for="g_scope_{{scope.id}}">
                                     <strong>{{scope.name}}</strong>
                                     <small ng-show="scope.description">{{scope.description}}</small>
                                 </label>

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Social.less
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Social.less
@@ -176,6 +176,11 @@
         label, input[type=checkbox] {
             margin: 0;
         }
+        table {
+            tbody > tr.selected {
+                background-color: #e7f2fd;        
+            }
+        }   
     }
 
     > div {

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Social.less
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Social.less
@@ -177,8 +177,13 @@
             margin: 0;
         }
         table {
-            tbody > tr.selected {
-                background-color: #e7f2fd;        
+            tbody > tr {
+               label {
+                   display: block;
+               }
+               &.selected {
+                    background-color: #e7f2fd;        
+                }
             }
         }   
     }


### PR DESCRIPTION
Issue: https://github.com/abjerner/Skybrud.Social.Umbraco/issues/14

Fixed selection of scopes by clicking labels in Facebook OAuth scopes dialog and changes Google to similar naming.

Ensure label use full width of the row cell and added a class to selected scope rows.