### PR TITLE
Adjust profile image

### DIFF
--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/PropertyEditor.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/PropertyEditor.html
@@ -9,7 +9,7 @@
                 <strong>{{model.value.name}}</strong> <span style="font-size: 12px;">(ID: {{model.value.id}})</span>
             </div>
                 
-            <button ng-click="clear()" prevent-default="" style="float: left;">Clear</button>
+            <button class="btn" ng-click="clear()" prevent-default="" style="float: left;">Clear</button>
             
             
             <div ng-show="expiresDays != NaN" style="float: left; line-height: 26px; padding-left: 5px; font-size: 12px;">

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/PropertyEditor.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Facebook/OAuth/PropertyEditor.html
@@ -2,7 +2,10 @@
 
     <div ng-show="model.value">
         <div style="float: left; margin-right: 10px;">
-            <img src="https://graph.facebook.com/{{model.value.id}}/picture?type=small" width="50" height="50" alt="" />
+            <img src="https://graph.facebook.com/{{model.value.id}}/picture?width=50&height=50"
+                 srcset="https://graph.facebook.com/{{model.value.id}}/picture?width=100&height=100 2x,
+                         https://graph.facebook.com/{{model.value.id}}/picture?width=150&height=150 3x"
+                 width="50" height="50" alt="" />
         </div>
         <div style="float: left; margin-right: 10px;">
             <div style="margin-bottom: 5px;">

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/PropertyEditor.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Google/OAuth/PropertyEditor.html
@@ -8,7 +8,7 @@
             <div style="margin-bottom: 5px;">
                 <strong>{{model.value.name}}</strong> <span style="font-size: 12px;">(ID: {{model.value.id}})</span>
             </div>
-            <button ng-click="clear()" prevent-default="" style="float: left;">Clear</button>
+            <button class="btn" ng-click="clear()" prevent-default="" style="float: left;">Clear</button>
         </div>
         <div style="clear: both;"></div>
     </div>

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Instagram/OAuth/PropertyEditor.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Instagram/OAuth/PropertyEditor.html
@@ -8,7 +8,7 @@
             <div style="margin-bottom: 5px;">
                 <strong>{{model.value.name}}</strong> <span style="font-size: 12px;">(ID: {{model.value.id}})</span>
             </div>
-            <button ng-click="clear()" prevent-default="" style="float: left;">Clear</button>
+            <button class="btn" ng-click="clear()" prevent-default="" style="float: left;">Clear</button>
         </div>
         <div style="clear: both;"></div>
     </div>

--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Twitter/OAuth/PropertyEditor.html
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Twitter/OAuth/PropertyEditor.html
@@ -8,7 +8,7 @@
             <div style="margin-bottom: 5px;">
                 <strong>{{model.value.name}}</strong> <span style="font-size: 12px;">(ID: {{model.value.id}})</span>
             </div>
-            <button ng-click="clear()" prevent-default="" style="float: left;">Clear</button>
+            <button class="btn" ng-click="clear()" prevent-default="" style="float: left;">Clear</button>
         </div>
         <div style="clear: both;"></div>
     </div>


### PR DESCRIPTION
I have added the class `btn` to clear button as well.

Furthermore I have added retina image for Facebook profile image using `srcset` for high resolution screens. http://caniuse.com/#search=srcset

Before
![image](https://cloud.githubusercontent.com/assets/2919859/22604084/355c22fc-ea4a-11e6-8217-a3ea94a84651.png)

After
![image](https://cloud.githubusercontent.com/assets/2919859/22604121/6296b494-ea4a-11e6-8f04-06a7d50a5fb2.png)

Instagram also have different image sizes and is quite low quality compared to the Facebook image.
https://scontent.cdninstagram.com/t51.2885-19/s50x50/12797758_1527866694182800_2110677219_a.jpg
https://scontent.cdninstagram.com/t51.2885-19/s100x100/12797758_1527866694182800_2110677219_a.jpg
https://scontent.cdninstagram.com/t51.2885-19/s150x150/12797758_1527866694182800_2110677219_a.jpg (this size is used)