### PR TITLE
Changed Twitter UserId to a string rather than long

### DIFF
--- a/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Dialogs/TwitterOAuth.aspx.cs
+++ b/src/Skybrud.Social.Umbraco/App_Plugins/Skybrud.Social/Dialogs/TwitterOAuth.aspx.cs
@@ -128,7 +128,7 @@ namespace Skybrud.Social.Umbraco.App_Plugins.Skybrud.Social.Dialogs {
 
                     // Set the callback data
                     TwitterOAuthData data = new TwitterOAuthData {
-                        Id = user.Id,
+                        IdStr = user.IdStr,
                         ScreenName = user.ScreenName,
                         Name = String.IsNullOrEmpty(user.Name) ? "" : user.Name,
                         Avatar = user.ProfileImageUrlHttps,

--- a/src/Skybrud.Social.Umbraco/Twitter/PropertyEditors/OAuth/TwitterOAuthData.cs
+++ b/src/Skybrud.Social.Umbraco/Twitter/PropertyEditors/OAuth/TwitterOAuthData.cs
@@ -17,9 +17,24 @@ namespace Skybrud.Social.Umbraco.Twitter.PropertyEditors.OAuth {
 
         /// <summary>
         /// Gets the ID of the authenticated user.
+        /// String need to be used due to javascript limitations on large numbers
         /// </summary>
         [JsonProperty("id")]
-        public long Id { get; set; }
+        public string IdStr { get; set; }
+
+        /// <summary>
+        /// Gets the ID of the authenticated user.
+        /// </summary>
+        [JsonIgnore]
+        public long Id
+        {
+            get
+            {
+                long defaultValue = 0;
+                long.TryParse(IdStr, out defaultValue);
+                return defaultValue;
+            }
+        }
 
         /// <summary>
         /// Gets the screen name of the authenticated user.


### PR DESCRIPTION
Recently had an issue with a clients Twitter account where the id was 18 characters long so the value was being rounded due to the JavaScript limitation on Number size causing an invalid Id to be stored in the database

I have amended so that the TwitterOAuthData model has a string property for the Id of the account which allows the value to be parsed correctly in the JavaScript controller 